### PR TITLE
use python3 build by default

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -1,6 +1,6 @@
 name: kernel
 
-on: push
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,6 +1,6 @@
 name: node
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build:

--- a/scripts/build_antlr.mjs
+++ b/scripts/build_antlr.mjs
@@ -1,19 +1,18 @@
 import { spawnSync } from 'child_process'
 import { renameSync } from 'fs'
 import { chdir } from 'process'
-import { SOURCE_DATE_EPOCH, ensure, encoding } from './util.mjs'
+import { SOURCE_DATE_EPOCH, ensure, encoding, python } from './util.mjs'
 
 const version = '4.10'
 
 console.log('Start build_antlr.mjs.')
-
-ensure(spawnSync('pip', ['download', `antlr4-python3-runtime==${version}`], { encoding }), 'Fail to download antlr4.')
+ensure(spawnSync(python, ['-m', 'pip', 'download', `antlr4-python3-runtime==${version}`], { encoding }), 'Fail to download antlr4.')
 
 ensure(spawnSync('tar', ['xzf', `antlr4-python3-runtime-${version}.tar.gz`], { encoding }), 'Fail to extract antlr4.')
 
 chdir(`antlr4-python3-runtime-${version}`)
 
-ensure(spawnSync('python', ['-m', 'build', '--wheel'],
+ensure(spawnSync(python, ['-m', 'build', '--wheel'],
   { encoding, env: { ...process.env, SOURCE_DATE_EPOCH } }), 'Fail to build antlr4.')
 
 const wheel = `antlr4_python3_runtime-${version}-py3-none-any.whl`

--- a/scripts/build_wheel.mjs
+++ b/scripts/build_wheel.mjs
@@ -1,14 +1,14 @@
 import { spawnSync } from 'child_process'
 import { rename, readFileSync } from 'fs'
 import { chdir } from 'process'
-import { SOURCE_DATE_EPOCH, encoding, ensure } from './util.mjs'
+import { SOURCE_DATE_EPOCH, encoding, ensure, python } from './util.mjs'
 
 console.log('Start build_wheel.mjs.')
 
 const { kernelName, kernelVersion } = JSON.parse(readFileSync('package.json'))
 chdir('kernel')
 
-ensure(spawnSync('python', ['-m', 'build', '--wheel'],
+ensure(spawnSync(python, ['-m', 'build', '--wheel'],
   { encoding, env: { ...process.env, SOURCE_DATE_EPOCH } }))
 
 const wheel = `${kernelName}-${kernelVersion}-py3-none-any.whl`

--- a/scripts/util.mjs
+++ b/scripts/util.mjs
@@ -1,4 +1,7 @@
 import { exit } from 'process'
+import { execSync } from 'child_process'
+import os from 'os'
+
 
 const SOURCE_DATE_EPOCH = 315532800
 
@@ -16,4 +19,21 @@ function ensure (result, message) {
   exit(1)
 }
 
-export { SOURCE_DATE_EPOCH, encoding, ensure }
+// copy from https://github.com/antfu/ni/blob/main/src/utils.ts#L17
+function cmdExists(cmd) {
+  try {
+    execSync(
+      os.platform() === 'win32'
+        ? `cmd /c "(help ${cmd} > nul || exit 0) && where ${cmd} > nul 2> nul"`
+        : `command -v ${cmd}`,
+    )
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+const python = cmdExists("python3") ? "python3" : "python"
+
+export { SOURCE_DATE_EPOCH, encoding, ensure, cmdExists, python }

--- a/scripts/util.mjs
+++ b/scripts/util.mjs
@@ -2,7 +2,6 @@ import { exit } from 'process'
 import { execSync } from 'child_process'
 import os from 'os'
 
-
 const SOURCE_DATE_EPOCH = 315532800
 
 const encoding = 'utf-8'
@@ -20,20 +19,19 @@ function ensure (result, message) {
 }
 
 // copy from https://github.com/antfu/ni/blob/main/src/utils.ts#L17
-function cmdExists(cmd) {
+function cmdExists (cmd) {
   try {
     execSync(
       os.platform() === 'win32'
         ? `cmd /c "(help ${cmd} > nul || exit 0) && where ${cmd} > nul 2> nul"`
-        : `command -v ${cmd}`,
+        : `command -v ${cmd}`
     )
     return true
-  }
-  catch {
+  } catch {
     return false
   }
 }
 
-const python = cmdExists("python3") ? "python3" : "python"
+const python = cmdExists('python3') ? 'python3' : 'python'
 
 export { SOURCE_DATE_EPOCH, encoding, ensure, cmdExists, python }


### PR DESCRIPTION
In my devbox(Ubuntu 20.04.5 LTS),  The `python` command has been removed and replaced by `python3`, I think most of the latest Linux distributions and MacOS are designed this way. 